### PR TITLE
netrc.go: consider same machine may have different login names

### DIFF
--- a/netrc/examples/good.netrc
+++ b/netrc/examples/good.netrc
@@ -14,6 +14,8 @@ put src2/*
 
 machine ray login demo password mypassword
 
+machine ray login demo1 password demo1_password
+
 machine weirdlogin login uname password pass#pass
 
 machine google.com


### PR DESCRIPTION
git-lfs client currently only use the first machine that matched without considering login name.
https://github.com/git-lfs/git-lfs/issues/4324

This commit make it act like git. Which would also check login name if specified.
If login name is not given, it would pick the first machine that matched.