### PR TITLE
Use constant format string

### DIFF
--- a/netrc/netrc.go
+++ b/netrc/netrc.go
@@ -358,7 +358,7 @@ func newToken(rawb []byte) (*token, error) {
 			t.kind = tkComment // this is a comment
 			return &t, nil
 		}
-		return &t, fmt.Errorf("keyword expected; got " + string(tkind))
+		return &t, fmt.Errorf("keyword expected; got %s", string(tkind))
 	}
 	return &t, nil
 }


### PR DESCRIPTION
The `go vet -printf ./...` command, when run with Go 1.24 (and a matching Go version number in the `go.mod` file), now detects format strings that are not constants, as described in golang/go#60529.

We have one such non-constant format [string](https://github.com/git-lfs/go-netrc/blob/e96144b9a966a4381b8b4821c03ff37f8b9b32e8/netrc/netrc.go#L361) in the `newToken()` function of the `netrc` package, so we adjust it now to use a standard format string with a specifier verb.

This issue was [reported](https://github.com/git-lfs/git-lfs/issues/5968#issuecomment-2600792917) as part of git-lfs/git-lfs#5968.